### PR TITLE
Rename tab from "Content" to "Countries"

### DIFF
--- a/code/ProductByCountrySTD.php
+++ b/code/ProductByCountrySTD.php
@@ -40,7 +40,7 @@ class ProductByCountrySTD extends SiteTreeExtension {
 				new CheckboxSetField('ExcludedCountries', '', $includedCountries)
 			)
 		);
-		$fields->addFieldToTab('Root.Content', $tabs);
+		$fields->addFieldToTab('Root.Countries', $tabs);
 	}
 
 


### PR DESCRIPTION
Currently the include/exclude countries options are under a tab labelled "Content", this change makes them under a tab labelled "Countries"